### PR TITLE
Two small edits to signals and queries documentation

### DIFF
--- a/query_your_workflow/wf_query_dacx.py
+++ b/query_your_workflow/wf_query_dacx.py
@@ -7,7 +7,7 @@ To define a Query, set the Query decorator [`@workflow.query`](https://python.te
 
 **Customize names**
 
-You can have a name parameter to customize the Query's name, otherwise it defaults to the unqualified method `__name__`.
+You can have a name parameter to customize the Query's name, otherwise it defaults to the name of the query method.
 
 :::note
 

--- a/query_your_workflow/wf_query_dacx.py
+++ b/query_your_workflow/wf_query_dacx.py
@@ -7,7 +7,7 @@ To define a Query, set the Query decorator [`@workflow.query`](https://python.te
 
 **Customize names**
 
-You can have a name parameter to customize the Query's name, otherwise it defaults to the name of the query method.
+You can have a name parameter to customize the Query's name, otherwise it defaults to the name of the Query method.
 
 :::note
 

--- a/signal_your_workflow/wf_signal_dacx.py
+++ b/signal_your_workflow/wf_signal_dacx.py
@@ -17,7 +17,7 @@ Return values from Signal methods are ignored.
 
 **Customize names**
 
-You can have a name parameter to customize the Signal's name, otherwise it defaults to the name of the signal method.
+You can have a name parameter to customize the Signal's name, otherwise it defaults to the name of the Signal method.
 dacx"""
 
 

--- a/signal_your_workflow/wf_signal_dacx.py
+++ b/signal_your_workflow/wf_signal_dacx.py
@@ -10,14 +10,14 @@ A Signal has a name and can have arguments.
 - The arguments must be serializable.
 To define a Signal, set the Signal decorator [`@workflow.signal`](https://python.temporal.io/temporalio.workflow.html#signal) on the Signal function inside your Workflow.
 
-**Customize name**
-
 Non-dynamic methods can only have positional arguments.
 Temporal suggests taking a single argument that is an object or data class of fields that can be added to as needed.
 
 Return values from Signal methods are ignored.
 
-You can have a name parameter to customize the Signal's name, otherwise it defaults to the unqualified method `__name__`.
+**Customize names**
+
+You can have a name parameter to customize the Signal's name, otherwise it defaults to the name of the signal method.
 dacx"""
 
 


### PR DESCRIPTION
I noticed that the "Customize name" section header was out of place in the signals docs, so I've fixed that. I also clarified / made more user-friendly the language for the default name logic.
